### PR TITLE
Fix/npm token

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,15 +34,11 @@ jobs:
 
       - name: install dependencies
         run: pnpm i
-        env:
-          NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - name: build docs
         run: |
           npm run docs:build
           cp -r docs/dist ../pages
-        env:
-          NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - name: deploy
         run: |

--- a/.github/workflows/predocs.yml
+++ b/.github/workflows/predocs.yml
@@ -57,16 +57,12 @@ jobs:
       - name: install dependencies
         if: ${{ env.PR_TYPE != 'closed' }}
         run: pnpm i
-        env:
-          NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - name: build docs
         if: ${{ env.PR_TYPE != 'closed' }}
         run: |
           npm run docs:build
           cp -r docs/dist ../pages
-        env:
-          NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - name: deploy preview docs
         if: ${{ env.PR_TYPE != 'closed' }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -29,14 +29,13 @@ jobs:
 
       - name: install dependencies
         run: pnpm i
-        env:
-          NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - name: publish
         run: |
           git config user.name action
           git config user.email action@github.com
           npm run build
+          npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
           npm version prerelease --preid=${{ github.ref_name }} && npm publish --tag=${{ github.ref_name }}
         env:
           NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,13 +34,9 @@ jobs:
 
       - name: install dependencies
         run: pnpm i
-        env:
-          NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - name: run test script
         run: npm test
-        env:
-          NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - name: publish
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,7 @@ jobs:
           git config user.email action@github.com
           npm run build
           echo generating version ${{ inputs.version }}
+          npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
           npm version ${{ inputs.version }} && npm publish --tag=${{ inputs.channel }}
         env:
           NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,13 +30,9 @@ jobs:
 
       - name: install dependencies
         run: pnpm i
-        env:
-          NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - name: run test script
         run: npm test
-        env:
-          NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 tag-version-prefix="v"
 message="chore(release): %s :tada:[skip ci]"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marvelsq/experiment",
-  "version": "0.4.0",
+  "version": "0.4.0-test",
   "description": "personal experiment",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -100,5 +100,6 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "include": ["./src"]
+  "include": ["./src"],
+  "exclude": ["**/__tests__/**"]
 }


### PR DESCRIPTION
## CHANGES
remove redundant NPM_TOKEN, only publish step need

.npmrc
```diff
- //registry.npmjs.org/:_authToken=${NPM_TOKEN}
```

action config
```diff
- env:
-   NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
```

using `npm set config` in the action step
```diff
+ npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
```